### PR TITLE
Allow merging of plop args and generator args, improved docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ example/folder/
 example/change-me.txt
 .idea
 .vscode
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -548,3 +548,15 @@ module.exports = function(plop) {
 ```
 
 For more, [refer to the `plop-actions` README](https://github.com/plopjs/plop-actions#readme)
+
+### Further Customization
+
+While `plop` provides a great level of customization for CLI utility wrappers, there may be usecases where you simply
+want more control over the CLI experience while also utilizing the template generation code.
+
+Luckily, [`node-plop`](https://github.com/plopjs/node-plop/) may be for you! It's what the `plop` CLI itself is built
+upon and can be easily extended for other usage in the CLI. However, be warned, documentation is not quite as fleshed out
+for integration with `node-plop`. That is to say `Thar be dragons`.
+
+> We note lackluster documentation on `node-plop` integration not as a point of pride, but rather a word of warning.
+> If you'd like to contribute documentation to the project, please do so! We always welcome and encourage contributions! 

--- a/README.md
+++ b/README.md
@@ -520,34 +520,7 @@ And your `package.json` should look like the following:
 
 Many CLI utilities handle some actions for you, such as running `git init` or `npm install` once the template is generated.
 
-While we'd like to provide these actions, we also want to keep the core actions limited in scope. As such, we provide an additional
-package [`plop-actions`](https://github.com/plopjs/plop-actions) to do just that.
-
-```javascript
-const {gitInit} = require('plop-actions');
-
-module.exports = function(plop) {
-  plop.setActionType('gitInit', gitInit);
-
-  plop.setGenerator('generate', {
-    prompts: [
-        // ...
-    ],
-    actions: function(data) {
-      const actions = [];
-
-      actions.push({
-        type: 'gitInit',
-        path: `${process.cwd()}/project-name/`,
-        // By default is false, but if "true" will log the output of commands
-        verbose: true
-      })
-    }
-  })
-}
-```
-
-For more, [refer to the `plop-actions` README](https://github.com/plopjs/plop-actions#readme)
+While we'd like to provide these actions, we also want to keep the core actions limited in scope. As such, we maintain a collection of libraries built to add these actions to Plop in [our Awesome Plop list](https://github.com/plopjs/awesome-plop). There, you'll be able to find options for those actions, or even build your own and add it to the list!
 
 ### Further Customization
 

--- a/src/input-processing.js
+++ b/src/input-processing.js
@@ -10,17 +10,21 @@ module.exports = {getBypassAndGenerator, handleArgFlags};
 /**
  * Parses the user input to identify the generator to run and any bypass data
  * @param plop - The plop context
+ * @param passArgsBeforeDashes - Should we pass args before `--` to the generator API
  */
-function getBypassAndGenerator(plop) {
-	// See if there are args to pass to generator
-	const eoaIndex = args.indexOf('--');
-	const {plopArgV, eoaArg} = (eoaIndex === -1
-		? {plopArgV: []}
-		: {
-			plopArgV: minimist(args.slice(eoaIndex + 1, args.length)),
-			eoaArg: args[eoaIndex + 1]
-		}
-	);
+function getBypassAndGenerator(plop, passArgsBeforeDashes) {
+    // See if there are args to pass to generator
+    const eoaIndex = args.indexOf('--');
+    const {plopArgV, eoaArg} = (
+        passArgsBeforeDashes ?
+            {plopArgV: argv} :
+            eoaIndex === -1
+                ? {plopArgV: []}
+                : {
+                    plopArgV: minimist(args.slice(eoaIndex + 1, args.length)),
+                    eoaArg: args[eoaIndex + 1]
+                }
+    );
 
   // locate the generator name based on input and take the rest of the
 	// user's input as prompt bypass data to be passed into the generator

--- a/src/plop.js
+++ b/src/plop.js
@@ -22,7 +22,19 @@ const Plop = new Liftoff({
 	v8flags: v8flags
 });
 
-function run(env) {
+/**
+ * The function to pass as the second argument to `Plop.launch`
+ * @param env - This is passed implicitly
+ * @param _ - Passed implicitly. Not needed, but allows for `passArgsBeforeDashes` to be explicitly passed
+ * @param passArgsBeforeDashes - An opt-in `true` boolean that will allow merging of plop CLI API and generator API
+ * @example
+ * Plop.launch({}, env => run(env, undefined, true))
+ *
+ * !!!!!! WARNING !!!!!!
+ * One of the reasons we default generator arguments as anything past `--` is a few reasons:
+ * Primarily that there may be name-spacing issues when combining the arg order and named arg passing
+ */
+function run(env, _, passArgsBeforeDashes) {
 	const plopfilePath = env.configPath;
 
 	// handle basic argument flags like --help, --version, etc
@@ -36,7 +48,7 @@ function run(env) {
 
 	const generators = plop.getGeneratorList();
 	const generatorNames = generators.map(v => v.name);
-	const {generatorName, bypassArr, plopArgV} = getBypassAndGenerator(plop);
+	const {generatorName, bypassArr, plopArgV} = getBypassAndGenerator(plop, passArgsBeforeDashes);
 
 	// look up a generator and run it with calculated bypass data
 	const runGeneratorByName = name => {


### PR DESCRIPTION
The following PR comes from a need that I faced while trying to use `plop` in a project for my company:

We wanted to remove the need for `--` and migrate towards using one set of arguments for both the plop arg API (`--force`) and the generator arg API (`--argName`). This would allow the following command to run:

```
plop --argName "Hello" --force
```

Instead of the default:

```
plop  --force -- --argName "Hello"
```

This is not set by default in the `plop` command, but is provided as an alternative API for `Plop.launch` for those looking to extend `plop` into making their own CLI utility. 

Currently, the documentation does not mention a usecase like this, so as such I've created a new "further reading" documentation section that covers just this.