### PR TITLE
feat: add args as parameter

### DIFF
--- a/src/input-processing.js
+++ b/src/input-processing.js
@@ -2,8 +2,7 @@ const chalk = require('chalk');
 const minimist = require('minimist');
 const out = require('./console-out');
 const globalPkg = require('../package.json');
-const args = process.argv.slice(2);
-const argv = minimist(args);
+
 
 module.exports = {getBypassAndGenerator, handleArgFlags};
 
@@ -12,7 +11,7 @@ module.exports = {getBypassAndGenerator, handleArgFlags};
  * @param plop - The plop context
  * @param passArgsBeforeDashes - Should we pass args before `--` to the generator API
  */
-function getBypassAndGenerator(plop, passArgsBeforeDashes) {
+function getBypassAndGenerator(plop, passArgsBeforeDashes, args, argv) {
     // See if there are args to pass to generator
     const eoaIndex = args.indexOf('--');
     const {plopArgV, eoaArg} = (
@@ -59,7 +58,7 @@ function listHasOptionThatStartsWith(list, prefix) {
  * Handles all basic argument flags
  * @param env - Values parsed by Liftoff
  */
-function handleArgFlags(env) {
+function handleArgFlags(env, argv) {
 	// Make sure that we're not overwritting `help`, `init,` or `version` args in generators
 	if (argv._.length === 0) {
 		// handle request for usage and options

--- a/src/plop.d.ts
+++ b/src/plop.d.ts
@@ -15,5 +15,5 @@ export {
 } from 'node-plop';
 
 export const Plop: Liftoff;
-export const run: (env: Liftoff.LiftoffEnv, _: any, passArgsBeforeDashes: boolean) => void;
+export const run: (env: Liftoff.LiftoffEnv, _: any, passArgsBeforeDashes: boolean, args?:string[]) => void;
 export const progressSpinner: ora.Ora;


### PR DESCRIPTION
Hi guy,

I need to use plop, under another generl cli, built with a cli framework 
https://github.com/oclif/oclif

so we need to slice argv with parent cli commands.

this PR allow this with the callback.

usage:

  Plop.launch({
       ...
      }, env => runPlop(env, undefined, false, process.argv.slice(X)))