### PR TITLE
Resolve extension of main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "plop",
   "version": "3.0.2",
   "description": "Micro-generator framework that makes it easy for an entire team to create files with a level of uniformity",
-  "main": "./src/plop",
+  "main": "./src/plop.js",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm getting the following warning coming from this package:
```
node:63582) [DEP0151] DeprecationWarning: 
Package .../node_modules/plop/ has a "main" field set to "./src/plop", 
excluding the full filename and extension to the resolved file at "src/plop.js", imported from .../index.js.
Automatic extension resolution of the "main" field is deprecated for ES modules.
```