### PR TITLE
 Add builtin actions to a plop's set of action types

### DIFF
--- a/packages/node-plop/src/generator-runner.js
+++ b/packages/node-plop/src/generator-runner.js
@@ -1,7 +1,6 @@
 "use strict";
 
 import promptBypass from "./prompt-bypass.js";
-import * as buildInActions from "./actions/index.js";
 
 export default function (plopfileApi, flags) {
   let abort;
@@ -46,8 +45,7 @@ export default function (plopfileApi, flags) {
     const changes = []; // array of changed made by the actions
     const failures = []; // array of actions that failed
     let { actions } = genObject; // the list of actions to execute
-    const customActionTypes = getCustomActionTypes();
-    const actionTypes = Object.assign({}, customActionTypes, buildInActions);
+    const actionTypes = getActionTypes();
 
     abort = false;
 
@@ -185,7 +183,7 @@ export default function (plopfileApi, flags) {
   };
 
   // request the list of custom actions from the plopfile
-  function getCustomActionTypes() {
+  function getActionTypes() {
     return plopfileApi.getActionTypeList().reduce(function (types, name) {
       types[name] = plopfileApi.getActionType(name);
       return types;

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -7,9 +7,11 @@ import resolve from "resolve";
 
 import bakedInHelpers from "./baked-in-helpers.js";
 import generatorRunner from "./generator-runner.js";
+import * as buildInActions from "./actions";
 
 import { createRequire } from "node:module";
 import { pathToFileURL } from "url";
+
 const require = createRequire(import.meta.url);
 
 async function nodePlop(plopfilePath = "", plopCfg = {}) {
@@ -20,7 +22,7 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
   const { destBasePath, force } = plopCfg;
   const generators = {};
   const partials = {};
-  const actionTypes = {};
+  const actionTypes = { ...buildInActions };
   const helpers = Object.assign(
     {
       pkg: (propertyPath) => _get(pkgJson, propertyPath, ""),

--- a/packages/node-plop/tests/get-action-type-list/get-action-type-list.spec.js
+++ b/packages/node-plop/tests/get-action-type-list/get-action-type-list.spec.js
@@ -1,0 +1,29 @@
+import nodePlop from "../../src/index.js";
+import { setupMockPath } from "../helpers/path.js";
+const { clean } = setupMockPath(import.meta.url);
+
+describe("get-generator-list", function () {
+  afterEach(clean);
+
+  let plop;
+  beforeEach(async () => {
+    plop = await nodePlop();
+  });
+
+  test("custom actions show in the list", function () {
+    plop.setActionType("foo", () => {});
+
+    const list = plop.getActionTypeList();
+
+    expect(list.includes("foo")).toBe(true);
+  });
+
+  test("custom actions show in the list", function () {
+    const list = plop.getActionTypeList();
+
+    expect(list.includes("add")).toBe(true);
+    expect(list.includes("modify")).toBe(true);
+    expect(list.includes("addMany")).toBe(true);
+    expect(list.includes("append")).toBe(true);
+  });
+});

--- a/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
@@ -86,7 +86,7 @@ describe("load-assets-from-plopfile", function () {
     expect(gNameList.length).toBe(3);
     expect(plop.getHelperList().length).toBe(3);
     expect(plop.getPartialList().length).toBe(3);
-    expect(plop.getActionTypeList().length).toBe(1);
+    expect(plop.getActionTypeList().length).toBe(5);
     expect(gNameList.includes("test-generator1")).toBe(true);
     expect(plop.getHelperList().includes("test-helper2")).toBe(true);
     expect(plop.getPartialList().includes("test-partial3")).toBe(true);


### PR DESCRIPTION
Mostly so that I can go `plop.getActionType('add')` (or any other built-in action) from a plopfile and get it.

This PR was originally made by @yanick for the `node-plop` repo and migrated by hand by me