### PR TITLE
Shorthand to load all plop assets

### DIFF
--- a/.changeset/old-balloons-look.md
+++ b/.changeset/old-balloons-look.md
@@ -1,0 +1,6 @@
+---
+"node-plop": minor
+"plop": minor
+---
+
+Added shorthand to load all Plop assets at once #333

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -125,25 +125,25 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
         const genNameList = proxy.getGeneratorList().map((g) => g.name);
         loadAsset(
           genNameList,
-          include.generators,
+          includeCfg === true || include.generators,
           setGenerator,
           (proxyName) => ({ proxyName, proxy })
         );
         loadAsset(
           proxy.getPartialList(),
-          include.partials,
+          includeCfg === true || include.partials,
           setPartial,
           proxy.getPartial
         );
         loadAsset(
           proxy.getHelperList(),
-          include.helpers,
+          includeCfg === true || include.helpers,
           setHelper,
           proxy.getHelper
         );
         loadAsset(
           proxy.getActionTypeList(),
-          include.actionTypes,
+          includeCfg === true || include.actionTypes,
           setActionType,
           proxy.getActionType
         );

--- a/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
@@ -93,6 +93,21 @@ describe("load-assets-from-plopfile", function () {
     expect(plop.getActionTypeList().includes("test-actionType1")).toBe(true);
   });
 
+  test("plop.load passes a config option that can be used to include all the plopfile output", async function () {
+    const plop = await nodePlop();
+    plop.load(plopfilePath, { prefix: "test-" }, true);
+
+    const gNameList = plop.getGeneratorList().map((g) => g.name);
+    expect(gNameList.length).toBe(3);
+    expect(plop.getHelperList().length).toBe(3);
+    expect(plop.getPartialList().length).toBe(3);
+    expect(plop.getActionTypeList().length).toBe(1);
+    expect(gNameList.includes("test-generator1")).toBe(true);
+    expect(plop.getHelperList().includes("test-helper2")).toBe(true);
+    expect(plop.getPartialList().includes("test-partial3")).toBe(true);
+    expect(plop.getActionTypeList().includes("test-actionType1")).toBe(true);
+  });
+
   test("plop.load should import functioning assets", async function () {
     const plop = await nodePlop();
     await plop.load(

--- a/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
@@ -95,7 +95,7 @@ describe("load-assets-from-plopfile", function () {
 
   test("plop.load passes a config option that can be used to include all the plopfile output", async function () {
     const plop = await nodePlop();
-    plop.load(plopfilePath, { prefix: "test-" }, true);
+    await plop.load(plopfilePath, { prefix: "test-" }, true);
 
     const gNameList = plop.getGeneratorList().map((g) => g.name);
     expect(gNameList.length).toBe(3);

--- a/packages/plop/plop-load.md
+++ b/packages/plop/plop-load.md
@@ -18,11 +18,11 @@ plop.load
 `config` is an object that can be passed to the plopfile or `plop-pack` when they are run. This allows the consumer of the plopfile or `plop-pack` to configure certain aspects of its functionality. To know what properties should be in this object, see the documentation provided by the author.
 
 #### include
-- **type:** `Object`
+- **type:** `Object` or `Boolean`
 - **default:** `{ generators:true, helpers:false, partials:false, actionTypes:false }`
 - **optional**
 
-`include` is an object that can contain 4 properties (`generators`, `helpers`, `partials`, and `actionTypes`). Each of these properties should have an [`IncludeDefinition`](#IncludeDefinition) as its value. Most of the time this object is not needed because the plopfile or `plop-pack` is able to specify a default [`IncludeDefinition`](#IncludeDefinition) to be used.
+If `include` is `true` all assets from the target will be included (none if `false`). Otherwise, `include` should be an object that can contain 4 properties (`generators`, `helpers`, `partials`, and `actionTypes`). Each of these properties should have an [`IncludeDefinition`](#Interface-IncludeDefinition) as its value. Most of the time this object is not needed because the plopfile or `plop-pack` is able to specify a default [`IncludeDefinition`](#Interface-IncludeDefinition) to be used.
 
 #### Interface `IncludeDefinition`
 - **Boolean:** `true` will include all assets, `false` will include non of them.
@@ -34,6 +34,11 @@ plop.load
 ```javascript
 	// loads all 5 generators, no helpers, actionTypes or partials (even if they exist)
 	plop.load('./plopfiles/component.js');
+```
+*load all assets from a path*
+```javascript
+	// loads all 5 generators, all helpers, actionTypes and partials (if they exist)
+	plop.load('./plopfiles/component.js', {}, true);
 ```
 *load via a path with a custom include config*
 ```javascript


### PR DESCRIPTION
> This PR was originally made by @RobinKnipe in the `node-plop` dedicated repo and moved over by hand to me: https://github.com/plopjs/node-plop/pull/187

Currently the `load` function doesn't include all assets when the `includeCfg` option is set to `true`.
The suggested code change should allow a shorthand to include all assets:
```js
plop.load('plopfile', {}, true)
```

This is a fix for issue: plopjs/plop#326 

Suggested changes to the `plop.load` doc here: https://github.com/plopjs/plop/pull/243