### PR TITLE
Escape special characters in append unique actions

### DIFF
--- a/packages/node-plop/src/actions/_common-action-utils.js
+++ b/packages/node-plop/src/actions/_common-action-utils.js
@@ -77,3 +77,12 @@ export async function getTransformedTemplate(template, data, cfg) {
     return template;
   }
 }
+
+/**
+ * Escape special characters in a regular expression string.
+ * This ensures that replacement text with special chars like *
+ * work when they are used in template replacements.
+ */
+export function escapeRegExp(text) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+}

--- a/packages/node-plop/src/actions/append.js
+++ b/packages/node-plop/src/actions/append.js
@@ -5,6 +5,7 @@ import {
   makeDestPath,
   throwStringifiedError,
   getRelativeToBasePath,
+  escapeRegExp,
 } from "./_common-action-utils.js";
 
 import actionInterfaceTest from "./_common-action-interface-check.js";
@@ -20,7 +21,7 @@ const doAppend = async function (data, cfg, plop, fileData) {
     const parts = fileData.split(cfg.pattern);
     const lastPart = parts[parts.length - 1];
     const lastPartWithoutDuplicates = lastPart.replace(
-      new RegExp(separator + stringToAppend, "g"),
+      new RegExp(escapeRegExp(separator + stringToAppend), "g"),
       ""
     );
     fileData = fileData.replace(lastPart, lastPartWithoutDuplicates);


### PR DESCRIPTION
> This PR was originally made by @soulfresh in the node-plop dedicated repo and moved over by hand to me: https://github.com/plopjs/node-plop/pull/207

### What does this PR do?

Updates the append action to escape special characters in the replacement text when using the unique configuration. 

Resolves https://github.com/plopjs/plop/issues/275.

Here is the failing scenario:

```js
// index.js template
/* PLOP_INJECT_EXPORT */
export * from './foo';
```

```js
// plopfile.js action definition
ACTION: {
  type: 'append',
  data: {},
  path: indexFilePath,
  template: "export * from './foo';",
  pattern: '/* PLOP_INJECT_EXPORT */',
  unique: true,
}
```

```js
// index.js file result
/* PLOP_INJECT_EXPORT */
export * from './foo';
export * from './foo';
```

This PR ensures the duplicates don't end up in the output.

Relates to https://github.com/plopjs/plop/issues/174