### PR TITLE
added PlopGeneratorConfig to exports in plop

### DIFF
--- a/packages/plop/src/plop.d.ts
+++ b/packages/plop/src/plop.d.ts
@@ -11,6 +11,7 @@ export {
   PlopCfg,
   PlopGenerator,
   NodePlopAPI,
+  PlopGeneratorConfig,
 } from "node-plop";
 
 export const Plop: Liftoff;


### PR DESCRIPTION
runActions and runPrompts are required by types definition, added PlopGeneratorConfig member to exports in plop. Fixes #339 