### PR TITLE
fix: Append action's templateFile string not processed by handlebars

### DIFF
--- a/packages/node-plop/src/actions/append.js
+++ b/packages/node-plop/src/actions/append.js
@@ -11,7 +11,6 @@ import {
 import actionInterfaceTest from "./_common-action-interface-check.js";
 
 const doAppend = async function (data, cfg, plop, fileData) {
-  cfg.templateFile = getRenderedTemplatePath(data, cfg, plop);
   const stringToAppend = await getRenderedTemplate(data, cfg, plop);
   // if the appended string should be unique (default),
   // remove any occurence of it (but only if pattern would match)
@@ -54,6 +53,7 @@ export default async function (data, cfg, plop) {
       throw "File does not exist";
     } else {
       let fileData = await fspp.readFile(fileDestPath);
+      cfg.templateFile = getRenderedTemplatePath(data, cfg, plop);
       fileData = await doAppend(data, cfg, plop, fileData);
       await fspp.writeFile(fileDestPath, fileData);
     }

--- a/packages/node-plop/src/actions/append.js
+++ b/packages/node-plop/src/actions/append.js
@@ -2,6 +2,7 @@ import * as fspp from "../fs-promise-proxy.js";
 
 import {
   getRenderedTemplate,
+  getRenderedTemplatePath,
   makeDestPath,
   throwStringifiedError,
   getRelativeToBasePath,
@@ -10,6 +11,7 @@ import {
 import actionInterfaceTest from "./_common-action-interface-check.js";
 
 const doAppend = async function (data, cfg, plop, fileData) {
+  cfg.templateFile = getRenderedTemplatePath(data, cfg, plop);
   const stringToAppend = await getRenderedTemplate(data, cfg, plop);
   // if the appended string should be unique (default),
   // remove any occurence of it (but only if pattern would match)

--- a/packages/node-plop/tests/dynamic-template-file/plopfile.js
+++ b/packages/node-plop/tests/dynamic-template-file/plopfile.js
@@ -33,6 +33,12 @@ export default function (plop) {
         templateFile: "plop-templates/change-me.txt",
       },
       {
+        type: "append",
+        path: "src/change-me.txt",
+        pattern: /(-- APPEND ITEMS HERE --)/gi,
+        templateFile: "plop-templates/{{dashCase kind}}.txt",
+      },
+      {
         type: "modify",
         path: "src/change-me.txt",
         pattern: /(-- APPEND ITEMS HERE --)/gi,


### PR DESCRIPTION
resolves #351 by treating the templateFile property of the 'append' action the same way the 'modify' action does