### PR TITLE
Empty checkbox bypass

### DIFF
--- a/packages/node-plop/src/prompt-bypass.js
+++ b/packages/node-plop/src/prompt-bypass.js
@@ -80,6 +80,10 @@ const typeBypass = {
     throw Error("invalid input");
   },
   checkbox(v, prompt) {
+    if (v === "") {
+      return [];
+    }
+
     const valList = v.split(",");
     const valuesNoMatch = valList.filter(
       (val) => !prompt.choices.some((c, idx) => choiceMatchesValue(c, idx, val))

--- a/packages/node-plop/tests/prompt-bypass-checkbox/prompt-bypass-checkbox.spec.js
+++ b/packages/node-plop/tests/prompt-bypass-checkbox/prompt-bypass-checkbox.spec.js
@@ -66,6 +66,10 @@ describe("prompt-bypass-checkbox", function () {
     );
     expect(Array.isArray(someAnswersByMixed.checkbox)).toBe(true);
     expect(JSON.stringify(someAnswersByMixed.checkbox)).toBe('["one","three"]');
+
+    const [, noAnswers] = await promptBypass(prompts, [""], plop);
+    expect(Array.isArray(noAnswers.checkbox)).toBe(true);
+    expect(JSON.stringify(noAnswers.checkbox)).toBe("[]");
   });
 
   test("verify bad bypass input", async function () {

--- a/packages/plop/tests/input-processing.spec.js
+++ b/packages/plop/tests/input-processing.spec.js
@@ -60,7 +60,7 @@ test("Should bypass generator prompt", async () => {
   expect(await findByText("What is your name?")).toBeInTheConsole();
 });
 
-test("Should bypass prompt by input", async () => {
+test("Should bypass input prompt with input", async () => {
   const { queryByText, findByText } = await renderPlop(["Frank"], {
     cwd: resolve(__dirname, "./examples/prompt-only"),
   });
@@ -71,7 +71,7 @@ test("Should bypass prompt by input", async () => {
   ).toBeInTheConsole();
 });
 
-test("Should bypass prompt by input placeholder", async () => {
+test("Should bypass input prompt with placeholder", async () => {
   const { queryByText, findByText, userEvent } = await renderPlop(
     ["_", "Cheese"],
     {
@@ -86,7 +86,7 @@ test("Should bypass prompt by input placeholder", async () => {
   ).not.toBeInTheConsole();
 });
 
-test("Should bypass prompt by name", async () => {
+test("Should bypass input prompt with name", async () => {
   const { queryByText, findByText } = await renderPlop(
     ["--", "--name", "Frank"],
     {
@@ -100,7 +100,7 @@ test("Should bypass prompt by name", async () => {
   ).toBeInTheConsole();
 });
 
-test("Should allow for empty string bypassing", async () => {
+test("Should bypass input prompt with empty string", async () => {
   const { queryByText, findByText } = await renderPlop(["--", "--name", `""`], {
     cwd: resolve(__dirname, "./examples/prompt-only"),
   });
@@ -109,6 +109,58 @@ test("Should allow for empty string bypassing", async () => {
   expect(
     await findByText("What pizza toppings do you like?")
   ).toBeInTheConsole();
+});
+
+test("Should bypass checkbox prompt with input", async () => {
+  const { queryByText } = await renderPlop(["Frank", "Cheese"], {
+    cwd: resolve(__dirname, "./examples/prompt-only"),
+  });
+
+  expect(await queryByText("What is your name?")).not.toBeInTheConsole();
+  expect(
+    await queryByText("What pizza toppings do you like?")
+  ).not.toBeInTheConsole();
+});
+
+test("Should bypass checkbox prompt with placeholder", async () => {
+  const { queryByText, findByText } = await renderPlop(["Frank", "_"], {
+    cwd: resolve(__dirname, "./examples/prompt-only"),
+  });
+
+  expect(await queryByText("What is your name?")).not.toBeInTheConsole();
+  expect(
+    await findByText("What pizza toppings do you like?")
+  ).toBeInTheConsole();
+});
+
+test("Should bypass checkbox prompt with name", async () => {
+  const { queryByText, findByText, userEvent } = await renderPlop(
+    ["--", "--toppings", "Cheese"],
+    {
+      cwd: resolve(__dirname, "./examples/prompt-only"),
+    }
+  );
+
+  expect(await findByText("What is your name?")).toBeInTheConsole();
+  userEvent.keyboard("[Enter]");
+  expect(
+    await queryByText("What pizza toppings do you like?")
+  ).not.toBeInTheConsole();
+});
+
+test("Should bypass checkbox prompt with empty string", async () => {
+  const { queryByText, findByText, userEvent } = await renderPlop(
+    ["--", "--toppings", `""`],
+    {
+      cwd: resolve(__dirname, "./examples/prompt-only"),
+    }
+  );
+
+  expect(await findByText("What is your name?")).toBeInTheConsole();
+  userEvent.keyboard("[Enter]");
+  expect(
+    await queryByText("What pizza toppings do you like?")
+  ).not.toBeInTheConsole();
 });
 
 test.todo("Dynamic actions");


### PR DESCRIPTION
In order to address #345 I added a check for an empty value in the `checkbox` bypass.

```javascript
    if (v === "") {
      return [];
    }
```

I think this solves the issue, but I haven't been able to test it from the top level. Is there another test file that I'm missing?

/cc @amwmedia @crutchcorn