### PR TITLE
Use type alias for inquirer module to avoid typescript error. Closes #357

### DIFF
--- a/packages/node-plop/types/index.d.ts
+++ b/packages/node-plop/types/index.d.ts
@@ -1,8 +1,10 @@
 import inquirer from "inquirer";
+
+type Inquirer = typeof inquirer;
+
 // @types/globby doesn't export types for GlobOptions, so we have to work a little bit to extract them:
 // GlobOptions is the second parameter of the sync function, which can be extracted with the Parameters<T> type
 import { globbySync } from "globby";
-
 type GlobOptions = Parameters<typeof globbySync>[1];
 import { HelperDelegate as HelperFunction } from "handlebars";
 
@@ -139,7 +141,7 @@ export type PromptQuestion =
   | inquirer.InputQuestion;
 
 export type DynamicPromptsFunction = (
-  inquirer: inquirer.Inquirer
+  inquirer: Inquirer
 ) => Promise<inquirer.Answers>;
 export type DynamicActionsFunction = (data?: inquirer.Answers) => ActionType[];
 


### PR DESCRIPTION
Patching this temporarily while waiting for this PR is non-trivial. As such I'm forced to abandon the library or use skipLibCheck for my shared generator package and all of it's dependents. Would love to see this get merged quickly! Thank you!