### PR TITLE
fix(node-plop): Set property `pattern` to optional in `AppendActionConfig` & `ModifyActionConfig`

### DIFF
--- a/.changeset/long-jars-roll.md
+++ b/.changeset/long-jars-roll.md
@@ -1,0 +1,5 @@
+---
+"node-plop": patch
+---
+
+Fix types for `AppendActionConfig` and `ModifyActionConfig` - the property `pattern` is now optional`

--- a/packages/node-plop/types/index.d.ts
+++ b/packages/node-plop/types/index.d.ts
@@ -251,7 +251,7 @@ export interface AddManyActionConfig
 interface ModifyActionConfigBase extends ActionConfig {
   type: "modify";
   path: string;
-  pattern: string | RegExp;
+  pattern?: string | RegExp;
   transform?: TransformFn<ModifyActionConfig>;
 }
 
@@ -260,7 +260,7 @@ export type ModifyActionConfig = ModifyActionConfigBase & TemplateStrOrFile;
 interface AppendActionConfigBase extends ActionConfig {
   type: "append";
   path: string;
-  pattern: string | RegExp;
+  pattern?: string | RegExp;
   unique: boolean;
   separator: string;
 }


### PR DESCRIPTION
According to the code from these lines:

- https://github.com/plopjs/plop/blob/main/packages/node-plop/src/actions/append.js#L32
- https://github.com/plopjs/plop/blob/973c1ce566db6fc754af55672b47ae4ed80ae4d0/packages/node-plop/s>

both actions types - `modify` and `optional` - accepts `pattern` option as optional.
