### PR TITLE
fix(node-plop): bypass list prompts with choices being a function

### DIFF
--- a/.changeset/small-planets-agree.md
+++ b/.changeset/small-planets-agree.md
@@ -1,0 +1,5 @@
+---
+"node-plop": minor
+---
+
+Ability to bypass choices prompts using a choices function

--- a/packages/node-plop/src/prompt-bypass.js
+++ b/packages/node-plop/src/prompt-bypass.js
@@ -56,8 +56,13 @@ const flag = {
 
 // generic list bypass function. used for all types of lists.
 // accepts value, index, or key as matching criteria
-const listTypeBypass = (v, prompt) => {
-  const choice = prompt.choices.find((c, idx) => choiceMatchesValue(c, idx, v));
+const listTypeBypass = (v, prompt, answers) => {
+  let choicesArray = prompt.choices;
+  if (typeof prompt.choices === 'function') {
+    choicesArray = prompt.choices(answers);
+  }
+
+  const choice = choicesArray.find((c, idx) => choiceMatchesValue(c, idx, v));
   if (choice != null) {
     return getChoiceValue(choice);
   }
@@ -166,7 +171,7 @@ export default async function (prompts, bypassArr, plop) {
       // get the real answer data out of the bypass function and attach it
       // to the answer data object
       const bypassIsFunc = typeof bypass === "function";
-      const value = bypassIsFunc ? bypass.call(null, val, p) : val;
+      const value = bypassIsFunc ? bypass.call(null, val, p, answers) : val;
 
       // if inquirer prompt has a filter function - call it
       const answer = p.filter ? p.filter(value, answers) : value;


### PR DESCRIPTION
Fixes #224

While #224 is closed with a workaround, that workaround does not work for me as I rely on a series of `list` prompts where the available choices depends on previously selected values.

This PR provides a simple fix for handling the `list` prompt when the `choices` property is a function. We pass the previous answers into bypass function, and in `listTypeBypass` we check if `choices` is a function and in that case invokes it to get the available choices as an array

I suppose this can be extended to support checkboxes as well, but that goes beyond my immediate need.