### PR TITLE
fix: inherit config

### DIFF
--- a/.changeset/wicked-needles-brake.md
+++ b/.changeset/wicked-needles-brake.md
@@ -1,0 +1,5 @@
+---
+"node-plop": patch
+---
+
+Fix passing configuration to loaded plopfiles.

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -100,6 +100,7 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
       targets = [targets];
     }
     const config = Object.assign(
+      {}, // forces shallow copy of plopCfg
       plopCfg,
       {
         destBasePath: getDestBasePath(),

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -100,6 +100,7 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
       targets = [targets];
     }
     const config = Object.assign(
+      plopCfg,
       {
         destBasePath: getDestBasePath(),
       },

--- a/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
@@ -173,4 +173,15 @@ describe("load-assets-from-plopfile", function () {
     expect(plop.getPartialList().length).toBe(1);
     expect(plop.getPartialList()[0]).toBe("p1");
   });
+
+  test.todo("plop.load loaded plopfile inherits config", async function () {
+    const plop = await nodePlop("", {
+      force: true,
+    });
+
+    await plop.load(plopfilePath, null, {});
+
+    // not a working test
+    expect(plop.config.force).toBe(true);
+  });
 });


### PR DESCRIPTION
Pass configuration from main plop to loaded plops.

Did not add tests, as I could not find anywhere to hook into to check the config values. Config is not exposed directly and doesn't seem to be exposed indirectly either. But I added a stub test, in case you know where to hook into and want to fix this quickly, or let me know and I can add another commit for the test.

Closes: #392