### PR TITLE
fix: Show generator description from external plopfiles

### DIFF
--- a/.changeset/spotty-feet-applaud.md
+++ b/.changeset/spotty-feet-applaud.md
@@ -1,0 +1,5 @@
+---
+"node-plop": patch
+---
+
+Show generator description from external plopfiles

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -127,7 +127,11 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
           genNameList,
           includeCfg === true || include.generators,
           setGenerator,
-          (proxyName) => ({ proxyName, proxy }),
+          (proxyName) => ({
+            proxyName,
+            proxy,
+            description: proxy.getGenerator(proxyName).description,
+          }),
         );
         loadAsset(
           proxy.getPartialList(),

--- a/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/load-assets-from-plopfile.spec.js
@@ -20,6 +20,14 @@ describe("load-assets-from-plopfile", function () {
     expect(plop.getPartialList().length).toBe(0);
   });
 
+  test("plop.load should preserve descriptions of generators", async function () {
+    const plop = await nodePlop();
+    await plop.load(plopfilePath);
+
+    expect(plop.getGeneratorList()[1].description).toBe(plop.getGenerator("generator2").description);
+    expect(plop.getGeneratorList()[1].description).toBe("this is a skeleton plopfile");
+  });
+
   test("plop.load should be able to include a subset of generators", async function () {
     const plop = await nodePlop();
     await plop.load(plopfilePath, {}, { generators: ["generator1"] });

--- a/packages/node-plop/tests/load-assets-from-plopfile/plopfile.js
+++ b/packages/node-plop/tests/load-assets-from-plopfile/plopfile.js
@@ -15,6 +15,9 @@ export default function (plop, config = {}) {
     actions: [{ type: "add", path: "src/{{name}}.txt" }],
   };
   plop.setGenerator(`${cfg.prefix}generator1`, generatorObject);
-  plop.setGenerator(`${cfg.prefix}generator2`, generatorObject);
+  plop.setGenerator(`${cfg.prefix}generator2`, {
+    ...generatorObject,
+    description: "this is a skeleton plopfile",
+  });
   plop.setGenerator(`${cfg.prefix}generator3`, generatorObject);
 }

--- a/packages/plop/tests/examples/javascript/extra-generators.plopfile.js
+++ b/packages/plop/tests/examples/javascript/extra-generators.plopfile.js
@@ -1,0 +1,18 @@
+export default function (plop) {
+  plop.setGenerator("extra-generator1", {
+    description: "this is a skeleton plopfile",
+    prompts: [
+      {
+        type: "input",
+        name: "name",
+        message: "What is your name?",
+        validate: function (value) {
+          if (/.+/.test(value)) {
+            return true;
+          }
+          return "name is required";
+        },
+      },
+    ],
+  });
+}

--- a/packages/plop/tests/examples/javascript/plopfile.js
+++ b/packages/plop/tests/examples/javascript/plopfile.js
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "fs";
 import inquirerDirectory from "inquirer-directory";
 
-export default function (plop) {
+export default async function (plop) {
   // starting prompt can be customized to display what you want
   // plop.setWelcomeMessage('[CUSTOM]'.yellow + ' What can I do for you?');
 
@@ -35,6 +35,9 @@ export default function (plop) {
     commentStart: "",
     commentEnd: "",
   });
+
+  // load generators from another plopfile in the project
+  await plop.load("./extra-generators.plopfile.js");
 
   const delayLog = (msg) => (answers) =>
     new Promise((resolve) => {

--- a/packages/plop/tests/input-processing.spec.js
+++ b/packages/plop/tests/input-processing.spec.js
@@ -50,6 +50,7 @@ test("Should handle generator prompt", async () => {
   await userEvent.keyboard("[Enter]");
 
   expect(await findByText("this is a test")).toBeInTheConsole();
+  expect(await findByText("this is a skeleton plopfile")).toBeInTheConsole();
 });
 
 test("Should bypass generator prompt", async () => {


### PR DESCRIPTION
When loading generators from external plop files with `plop.load(path)` their `description` was being lost. The root cause is that the [`proxy`](https://github.com/plopjs/plop/blob/5e217995c7267393bec57cd4386a67f51be39c14/packages/node-plop/src/node-plop.js#L130) object that we're passing to [`setGenerator()`](https://github.com/plopjs/plop/blob/5e217995c7267393bec57cd4386a67f51be39c14/packages/node-plop/src/node-plop.js#L61) doesn't have a `description` property, which judging by the rest of the code is by design. 

I did contemplate an alternative fix - to add the `description` in the `setGenerator` function like so:
```js
// add the generator to this context
generators[name] = Object.assign(
  {},
  config.proxy ? { description: config.proxy.getGenerator(name) } : {},
  config,
  {
    name: name,
    basePath: plopfilePath,
  },
);
```
but IMO the patch should be where the external plop file is loaded. 

This PR fixes the missing `description` logged in #247. 

---

Aside: @piersolenski observed that `setWelcomeMessage()` also is being lost, but I don't think it's a good design to allow the loaded files to change it. 