### PR TITLE
fix(engines): update engines to match top level package

### DIFF
--- a/packages/node-plop/package.json
+++ b/packages/node-plop/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/plopjs/plop/issues"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   },
   "devDependencies": {
     "@types/inquirer-autocomplete-prompt": "^3.0.0",

--- a/packages/plop/package.json
+++ b/packages/plop/package.json
@@ -51,7 +51,7 @@
     "v8flags": "^4.0.1"
   },
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   },
   "preferGlobal": true,
   "bin": "./bin/plop.js"

--- a/packages/plop/tests/examples/action-failure/package.json
+++ b/packages/plop/tests/examples/action-failure/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-action-failure",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/add-action/package.json
+++ b/packages/plop/tests/examples/add-action/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-add-action",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/cjs-js/package.json
+++ b/packages/plop/tests/examples/cjs-js/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-prompts-only",
   "type": "commonjs",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/cjs/package.json
+++ b/packages/plop/tests/examples/cjs/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-prompts-only",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/esm/package.json
+++ b/packages/plop/tests/examples/esm/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-prompts-only",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/javascript/package.json
+++ b/packages/plop/tests/examples/javascript/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/mjs/package.json
+++ b/packages/plop/tests/examples/mjs/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-prompts-only",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/prompt-only/package.json
+++ b/packages/plop/tests/examples/prompt-only/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-prompts-only",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }

--- a/packages/plop/tests/examples/wrap-plop/package.json
+++ b/packages/plop/tests/examples/wrap-plop/package.json
@@ -2,6 +2,6 @@
   "name": "plop-example-wrap",
   "type": "module",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
When updating to [plop 4](https://github.com/plopjs/plop/releases/tag/plop%404.0.0) and reading that support for Node 12, 14, and 16 was dropped, I was surprised that my Node 16 application was still able to install plop without a warning about the engine.

Updating these engines will ensure that consumers of plop will be notified on install that their version of node may be unsupported if it is below 18.