### PR TITLE
fix: windows ci usage

### DIFF
--- a/packages/plop/package.json
+++ b/packages/plop/package.json
@@ -32,7 +32,7 @@
     "postpublish": "node ./scripts/postpublish.js"
   },
   "devDependencies": {
-    "cli-testing-library": "^2.0.1",
+    "cli-testing-library": "^2.0.2",
     "inquirer-directory": "^2.2.0",
     "nyc": "^15.1.0",
     "plop-pack-fancy-comments": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,9 +2217,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-testing-library@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "cli-testing-library@npm:2.0.1"
+"cli-testing-library@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "cli-testing-library@npm:2.0.2"
   dependencies:
     "@babel/code-frame": "npm:^7.10.4"
     "@babel/runtime": "npm:^7.12.5"
@@ -2231,7 +2231,7 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     strip-final-newline: "npm:^2.0.0"
     tree-kill: "npm:^1.2.2"
-  checksum: 7aa6917510a5cf8bbe88609553a3eb56b704d4c3668db3f372422ab5df35e83a6eb216fced96c2d85350ea2636251060c635d00c8ca018e13b681869a64af8dc
+  checksum: c74ce125a3d222f78ff9482f7590dc5a6ce0e233386abbe3fdcf0819505d74ec1455ba71a2e51a194690af34db8c5675ffc1f791acaa4e27adc3207ae057dec3
   languageName: node
   linkType: hard
 
@@ -6580,7 +6580,7 @@ __metadata:
   dependencies:
     "@types/liftoff": "npm:^4.0.3"
     chalk: "npm:^5.3.0"
-    cli-testing-library: "npm:^2.0.1"
+    cli-testing-library: "npm:^2.0.2"
     inquirer-directory: "npm:^2.2.0"
     interpret: "npm:^3.1.1"
     liftoff: "npm:^4.0.0"


### PR DESCRIPTION
Per https://github.com/crutchcorn/cli-testing-library/issues/3 @Waldeedle fixed some of the issues with Windows running on CI. This PR updates the dep version to bring that to Plop