### PR TITLE
Enhancement: export Actions type

### DIFF
--- a/packages/plop/src/plop.d.ts
+++ b/packages/plop/src/plop.d.ts
@@ -12,6 +12,7 @@ export {
   PlopGenerator,
   NodePlopAPI,
   PlopGeneratorConfig,
+  Actions
 } from "node-plop";
 
 export const Plop: Liftoff;


### PR DESCRIPTION
A small enhancement to export the `Actions` type used in `setGenerator`, which can be handy for Typescript development