### PR TITLE
Typescript docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Because [context switching is expensive](https://www.petrikainulainen.net/softwa
 # Plopfile API
 The plopfile api is the collection of methods that are exposed by the `plop` object. Most of the work is done by [`setGenerator`](#setgenerator) but this section documents the other methods that you may also find useful in your plopfile.
 
-## TypeScript Declarations
+## TypeScript Support
 
-`plop` bundles TypeScript declarations.  Whether or not you write your plopfile in TypeScript, many editors will offer code assistance via these declarations.
+Plop bundles TypeScript declarations and supports TypeScript plopfiles via [NodeJS command line imports](https://nodejs.org/api/cli.html#--importmodule). 
 
 ```javascript
 // plopfile.ts
@@ -152,6 +152,35 @@ export default function (plop: NodePlopAPI) {
   // plop generator code
 };
 ```
+
+Plop can use a native `polopfile.ts` without compiling it ahead of time by using [tsx loaders](https://github.com/privatenumber/tsx?tab=readme-ov-file#nodejs-loader):
+
+```bash
+npm i -D tsx cross-env
+```
+
+**Node.js v20.6 and above**
+
+```json
+// package.json
+"scripts": {
+  "cross-env NODE_OPTIONS='--import tsx' plop --plopfile=plopfile.ts"
+}
+```
+
+**Node.js v20.5.1 and below**
+
+```json
+// package.json
+"scripts": {
+  "cross-env NODE_OPTIONS='--loader tsx' plop --plopfile=plopfile.ts"
+}
+```
+
+
+## JSDoc Support
+
+Whether or not you write your plopfile in TypeScript, many editors will offer code assistance via JSDoc declarations.
 
 ```javascript
 // plopfile.js

--- a/README.md
+++ b/README.md
@@ -130,21 +130,13 @@ $ plop component -- --type react
 ### Running a Generator Forcefully
 By default Plop actions keep your files safe by failing when things look fishy. The most obvious example of this is not allowing an [`add`](#add) action to overwrite a file that already exists. Plop actions individually support the `force` property but you can also use the `--force` flag when running Plop from the terminal. Using the `--force` flag will tell every action to run forcefully. With great power...🕷
 
-## Why Generators?
-Because when you create your boilerplate separate from your code, you naturally put more time and thought into it.
+### Using TypeScript plopfiles
 
-Because saving your team (or yourself) 5-15 minutes when creating every route, component, controller, helper, test, view, etc... [really adds up](https://xkcd.com/1205/).
+Plop bundles TypeScript declarations and supports TypeScript plopfiles via [tsx loaders](https://github.com/privatenumber/tsx?tab=readme-ov-file#nodejs-loader), a feature of [NodeJS command line imports](https://nodejs.org/api/cli.html#--importmodule). 
 
-Because [context switching is expensive](https://www.petrikainulainen.net/software-development/processes/the-cost-of-context-switching/) and saving time is not the only [benefit to automating workflows](https://kentcdodds.com/blog/automation)
+First, make a TypesScript plopfile:
 
-# Plopfile API
-The plopfile api is the collection of methods that are exposed by the `plop` object. Most of the work is done by [`setGenerator`](#setgenerator) but this section documents the other methods that you may also find useful in your plopfile.
-
-## TypeScript Support
-
-Plop bundles TypeScript declarations and supports TypeScript plopfiles via [NodeJS command line imports](https://nodejs.org/api/cli.html#--importmodule). 
-
-```javascript
+```ts
 // plopfile.ts
 import {NodePlopAPI} from 'plop';
 
@@ -153,11 +145,13 @@ export default function (plop: NodePlopAPI) {
 };
 ```
 
-Plop can use a native `polopfile.ts` without compiling it ahead of time by using [tsx loaders](https://github.com/privatenumber/tsx?tab=readme-ov-file#nodejs-loader):
+Next, install [tsx](https://github.com/privatenumber/tsx) and optionally [cross-env](https://www.npmjs.com/package/cross-env):
 
 ```bash
 npm i -D tsx cross-env
 ```
+
+Finally, use `NODE_OPTIONS` to activate the tsx loader. Now Plop can import your `plopfile.ts`:
 
 **Node.js v20.6 and above**
 
@@ -177,6 +171,19 @@ npm i -D tsx cross-env
 }
 ```
 
+## Why Generators?
+Because when you create your boilerplate separate from your code, you naturally put more time and thought into it.
+
+Because saving your team (or yourself) 5-15 minutes when creating every route, component, controller, helper, test, view, etc... [really adds up](https://xkcd.com/1205/).
+
+Because [context switching is expensive](https://www.petrikainulainen.net/software-development/processes/the-cost-of-context-switching/) and saving time is not the only [benefit to automating workflows](https://kentcdodds.com/blog/automation)
+
+# Plopfile API
+The plopfile api is the collection of methods that are exposed by the `plop` object. Most of the work is done by [`setGenerator`](#setgenerator) but this section documents the other methods that you may also find useful in your plopfile.
+
+## TypeScript Support
+
+Plop bundles TypeScript declarations. See [using TypeScript plopfiles](#using-typescript-plopfiles) for more details.
 
 ## JSDoc Support
 


### PR DESCRIPTION
Alright here's a first cut at the docs.

A couple suggestions to consider before merging:

1. Add an `--init-ts` switch for convenience. I added it [here](https://github.com/plopjs/plop/pull/427/files#diff-0e1d2f6ba310c5d8612a88994e5046a0b1f655606010658c0283db356fec6125R65) and can pull it in. Tests pass.
2. Test/verify that `plopfile.ts` is automatically searched. I believe Liftoff does, but it would be nice not to need `--plopfile=plopfile.ts`
3. There are [a couple test fixes](https://github.com/plopjs/plop/pull/427/files#diff-c9457e7b30292dd61fd2960ff81fa512203235db975a933794882645d7f61adc) I'd like to pull into this PR. The typescript test wasn't loading `plopfile.ts` and the `tsconfig.json` had a path error. All of this can be fixed and will work now with a simple `import 'tsx'` in the test suite.

Let me know :) 


