### PR TITLE
chore: add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "semi": true
+}


### PR DESCRIPTION
This seems to help VSCode maintain established formatting conventions.