### PR TITLE
fix: extend Action config to include CustomActionConfig

### DIFF
--- a/packages/node-plop/types/index.d.ts
+++ b/packages/node-plop/types/index.d.ts
@@ -215,7 +215,8 @@ export type ActionType =
   | AddManyActionConfig
   | ModifyActionConfig
   | AppendActionConfig
-  | CustomActionFunction;
+  | CustomActionFunction
+  | CustomActionConfig<string>;
 
 export interface ActionConfig {
   type: string;


### PR DESCRIPTION
This resolves the issue of typescript throwing object literal can't have property error for custom actions, because it was defaulting to type:ActionConfig whereas it should narrow down to a CustomACtionConfig
#439 