### PR TITLE
perf: drop lodash

### DIFF
--- a/packages/node-plop/package.json
+++ b/packages/node-plop/package.json
@@ -44,11 +44,11 @@
   "dependencies": {
     "@types/inquirer": "^9.0.9",
     "change-case": "^5.4.4",
+    "dlv": "^1.1.3",
     "globby": "^14.1.0",
     "handlebars": "^4.7.8",
     "inquirer": "^9.3.7",
     "isbinaryfile": "^5.0.6",
-    "lodash.get": "^4.4.2",
     "resolve": "^1.22.10",
     "title-case": "^4.3.2"
   }

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -12,8 +12,8 @@ import { createRequire } from "node:module";
 import { pathToFileURL } from "url";
 const require = createRequire(import.meta.url);
 
-const dlvBrackets = (obj, propertyPath) =>
-  dlv(obj, propertyPath.replace("[", ".").replace("]", ""));
+const dlvBrackets = (obj, propertyPath, defaultValue) =>
+  dlv(obj, propertyPath.replace("[", ".").replace("]", ""), defaultValue);
 
 async function nodePlop(plopfilePath = "", plopCfg = {}) {
   let pkgJson = {};

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import inquirer from "inquirer";
 import handlebars from "handlebars";
-import _get from "lodash.get";
+import dlv from "dlv";
 import resolve from "resolve";
 
 import bakedInHelpers from "./baked-in-helpers.js";
@@ -11,6 +11,9 @@ import generatorRunner from "./generator-runner.js";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "url";
 const require = createRequire(import.meta.url);
+
+const dlvBrackets = (obj, propertyPath) =>
+  dlv(obj, propertyPath.replace("[", ".").replace("]", ""));
 
 async function nodePlop(plopfilePath = "", plopCfg = {}) {
   let pkgJson = {};
@@ -23,7 +26,7 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
   const actionTypes = {};
   const helpers = Object.assign(
     {
-      pkg: (propertyPath) => _get(pkgJson, propertyPath, ""),
+      pkg: (propertyPath) => dlvBrackets(pkgJson, propertyPath, ""),
     },
     bakedInHelpers,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,6 +2510,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dlv@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "dlv@npm:1.1.3"
+  checksum: 10/836459ec6b50e43e9ed388a5fc28954be99e3481af3fa4b5d82a600762eb65ef8faacd454097ed7fc2f8a60aea2800d65a4cece5cd0d81ab82b2031f3f759e6e
+  languageName: node
+  linkType: hard
+
 "doctrine@npm:^3.0.0":
   version: 3.0.0
   resolution: "doctrine@npm:3.0.0"
@@ -4668,13 +4675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.get@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.get@npm:4.4.2"
-  checksum: 10/2a4925f6e89bc2c010a77a802d1ba357e17ed1ea03c2ddf6a146429f2856a216663e694a6aa3549a318cbbba3fd8b7decb392db457e6ac0b83dc745ed0a17380
-  languageName: node
-  linkType: hard
-
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
@@ -5181,12 +5181,12 @@ __metadata:
     "@types/inquirer-autocomplete-prompt": "npm:^3.0.3"
     "@types/node": "npm:^20.10.5"
     change-case: "npm:^5.4.4"
+    dlv: "npm:^1.1.3"
     dtslint: "npm:^4.2.1"
     globby: "npm:^14.1.0"
     handlebars: "npm:^4.7.8"
     inquirer: "npm:^9.3.7"
     isbinaryfile: "npm:^5.0.6"
-    lodash.get: "npm:^4.4.2"
     plop-pack-fancy-comments: "npm:^0.2.1"
     resolve: "npm:^1.22.10"
     title-case: "npm:^4.3.2"


### PR DESCRIPTION
Switches from lodash for property path getting to `dlv`.

Note that dlv doesn't handle square-bracket indexing (e.g. `foo[0]`) so we simply replace `[` with `.` and strip `]`. This means `foo.bar[0]` becomes `foo.bar.0`, etc.