### PR TITLE
perf: use built-in fs.rm

### DIFF
--- a/packages/node-plop/build-scripts/clean.js
+++ b/packages/node-plop/build-scripts/clean.js
@@ -1,3 +1,3 @@
-import { deleteSync } from "del";
+import { rmSync } from "node:fs";
 
-deleteSync("./lib");
+rmSync("./lib", { recursive: true, force: true });

--- a/packages/node-plop/package.json
+++ b/packages/node-plop/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@types/inquirer": "^9.0.9",
     "change-case": "^5.4.4",
-    "del": "^8.0.0",
     "globby": "^14.1.0",
     "handlebars": "^4.7.8",
     "inquirer": "^9.3.7",

--- a/packages/node-plop/src/actions/_common-action-add-file.js
+++ b/packages/node-plop/src/actions/_common-action-add-file.js
@@ -1,5 +1,5 @@
 import path from "path";
-import { deleteAsync } from "del";
+import { rm } from "node:fs/promises";
 import {
   getRenderedTemplate,
   getTransformedTemplate,
@@ -19,7 +19,7 @@ export default async function addFile(data, cfg, plop) {
 
     // if we are forcing and the file already exists, delete the file
     if (force === true && destExists) {
-      await deleteAsync([fileDestPath], { force });
+      await rm(fileDestPath, { force, recursive: true });
       destExists = false;
     }
 

--- a/packages/node-plop/tests/helpers/path.js
+++ b/packages/node-plop/tests/helpers/path.js
@@ -1,6 +1,6 @@
 import path from "path";
 import { normalizePath } from "../../src/actions/_common-action-utils.js";
-import { deleteAsync } from "del";
+import { rm } from "node:fs/promises";
 import * as fspp from "../../src/fs-promise-proxy.js";
 import { fileURLToPath } from "node:url";
 
@@ -14,12 +14,12 @@ export function setupMockPath(importMetaUrl) {
 
   async function clean() {
     // remove the src folder
-    await deleteAsync([normalizePath(testSrcPath)], { force: true });
+    await rm(normalizePath(testSrcPath), { force: true, recursive: true });
 
     try {
       const mockIsEmpty = (await fspp.readdir(mockPath)).length === 0;
       if (mockIsEmpty) {
-        await deleteAsync([mockPath], { force: true });
+        await rm(mockPath, { force: true, recursive: true });
       }
     } catch (err) {
       // there was no mock directory to remove

--- a/packages/node-plop/tests/imported-custom-action/custom-action.js
+++ b/packages/node-plop/tests/imported-custom-action/custom-action.js
@@ -1,11 +1,14 @@
-import { deleteAsync } from "del";
+import { rm } from "node:fs/promises";
 import * as fspp from "../../src/fs-promise-proxy.js";
 import { normalizePath } from "../../src/actions/_common-action-utils.js";
 
 export default async function (data, cfg /*, plop*/) {
   const removeFilePath = cfg.path;
   if (await fspp.fileExists(removeFilePath)) {
-    return await deleteAsync([normalizePath(removeFilePath)]);
+    return await rm(normalizePath(removeFilePath), {
+      force: true,
+      recursive: true,
+    });
   } else {
     throw `Path does not exist ${removeFilePath}`;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2475,20 +2475,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"del@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "del@npm:8.0.0"
-  dependencies:
-    globby: "npm:^14.0.2"
-    is-glob: "npm:^4.0.3"
-    is-path-cwd: "npm:^3.0.0"
-    is-path-inside: "npm:^4.0.0"
-    p-map: "npm:^7.0.2"
-    slash: "npm:^5.1.0"
-  checksum: 10/502dea7a846f989e1d921733f5d41ae4ae9b3eff168d335bfc050c9ce938ddc46198180be133814269268c4b0aed441a82fbace948c0ec5eed4ed086a4ad3b0e
-  languageName: node
-  linkType: hard
-
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -3655,7 +3641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^14.0.2, globby@npm:^14.1.0":
+"globby@npm:^14.1.0":
   version: 14.1.0
   resolution: "globby@npm:14.1.0"
   dependencies:
@@ -4225,24 +4211,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-cwd@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-path-cwd@npm:3.0.0"
-  checksum: 10/bc34d13b6a03dfca4a3ab6a8a5ba78ae4b24f4f1db4b2b031d2760c60d0913bd16a4b980dcb4e590adfc906649d5f5132684079a3972bd219da49deebb9adea8
-  languageName: node
-  linkType: hard
-
 "is-path-inside@npm:^3.0.3":
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: 10/abd50f06186a052b349c15e55b182326f1936c89a78bf6c8f2b707412517c097ce04bc49a0ca221787bc44e1049f51f09a2ffb63d22899051988d3a618ba13e9
-  languageName: node
-  linkType: hard
-
-"is-path-inside@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "is-path-inside@npm:4.0.0"
-  checksum: 10/8810fa11c58e6360b82c3e0d6cd7d9c7d0392d3ac9eb10f980b81f9839f40ac6d1d6d6f05d069db0d227759801228f0b072e1b6c343e4469b065ab5fe0b68fe5
   languageName: node
   linkType: hard
 
@@ -5261,7 +5233,6 @@ __metadata:
     "@types/inquirer-autocomplete-prompt": "npm:^3.0.3"
     "@types/node": "npm:^20.10.5"
     change-case: "npm:^5.4.4"
-    del: "npm:^8.0.0"
     dtslint: "npm:^4.2.1"
     globby: "npm:^14.1.0"
     handlebars: "npm:^4.7.8"
@@ -5657,13 +5628,6 @@ __metadata:
   dependencies:
     aggregate-error: "npm:^3.0.0"
   checksum: 10/7ba4a2b1e24c05e1fc14bbaea0fc6d85cf005ae7e9c9425d4575550f37e2e584b1af97bcde78eacd7559208f20995988d52881334db16cf77bc1bcf68e48ed7c
-  languageName: node
-  linkType: hard
-
-"p-map@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "p-map@npm:7.0.3"
-  checksum: 10/2ef48ccfc6dd387253d71bf502604f7893ed62090b2c9d73387f10006c342606b05233da0e4f29388227b61eb5aeface6197e166520c465c234552eeab2fe633
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Uses `rm` to remove directories instead of `del`.