### PR TITLE
Update docs about native TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ By default Plop actions keep your files safe by failing when things look fishy. 
 
 ### Using TypeScript plopfiles
 
+#### Node.js v22.18+**
+
+Modern Node.js supports TypeScript files [out-of-the-box](https://nodejs.org/docs/latest/api/typescript.html). No extra setup or CLI flags are required to use a TypeScript plopfile. Generate a TypesScript plopfile using `plop --init-ts` or by hand:
+
+```ts
+// plopfile.ts
+import { NodePlopAPI } from "plop";
+
+export default function (plop: NodePlopAPI) {
+  // plop generator code
+}
+```
+
+#### Older Node.js Versions**
+
 Plop bundles TypeScript declarations and supports TypeScript plopfiles via [tsx loaders](https://github.com/privatenumber/tsx?tab=readme-ov-file#nodejs-loader), a feature of [NodeJS command line imports](https://nodejs.org/api/cli.html#--importmodule).
 
 First, make a TypesScript plopfile using `plop --init-ts` or by hand:


### PR DESCRIPTION
Updating the [Using TypeScript plopfiles](https://github.com/plopjs/plop#using-typescript-plopfiles) section of the docs per [this Bluesky post](https://bsky.app/profile/raygesualdo.com/post/3lzbj346tys23) to note that recent versions of Node.js natively support TypeScript and don't require additional setup or configuration.