### PR TITLE
chore: remove dlv dependency

### DIFF
--- a/packages/node-plop/package.json
+++ b/packages/node-plop/package.json
@@ -45,7 +45,6 @@
     "@types/inquirer": "^9.0.9",
     "@types/picomatch": "^4.0.2",
     "change-case": "^5.4.4",
-    "dlv": "^1.1.3",
     "handlebars": "^4.7.8",
     "inquirer": "^9.3.8",
     "isbinaryfile": "^6.0.0",

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -12,10 +12,8 @@ import { pathToFileURL } from "url";
 const require = createRequire(import.meta.url);
 
 function dlvBrackets(obj, key, def) {
-	const k = key.replace("[", ".").replace("]", "").split(".");
-	for (let p = 0; p < k.length; p++) {
-		obj = obj?.[k[p]];
-	}
+	const ks = key.replace("[", ".").replace("]", "").split(".");
+  for (const k of ks) obj = obj?.[k];
 	return obj === undefined ? def : obj;
 }
 

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -11,10 +11,14 @@ import { createRequire } from "node:module";
 import { pathToFileURL } from "url";
 const require = createRequire(import.meta.url);
 
-function dlvBrackets(obj, key, def) {
-	const ks = key.replace("[", ".").replace("]", "").split(".");
-  for (const k of ks) obj = obj?.[k];
-	return obj === undefined ? def : obj;
+function dlvBrackets(obj, key) {
+  const result = key
+    .replace("[", ".")
+    .replace("]", "")
+    .split(".")
+    .reduce((acc, k) => acc?.[k], obj);
+
+  return result ?? "";
 }
 
 async function nodePlop(plopfilePath = "", plopCfg = {}) {
@@ -28,7 +32,7 @@ async function nodePlop(plopfilePath = "", plopCfg = {}) {
   const actionTypes = {};
   const helpers = Object.assign(
     {
-      pkg: (propertyPath) => dlvBrackets(pkgJson, propertyPath, ""),
+      pkg: (propertyPath) => dlvBrackets(pkgJson, propertyPath),
     },
     bakedInHelpers,
   );

--- a/packages/node-plop/src/node-plop.js
+++ b/packages/node-plop/src/node-plop.js
@@ -2,7 +2,6 @@ import fs from "fs";
 import path from "path";
 import inquirer from "inquirer";
 import handlebars from "handlebars";
-import dlv from "dlv";
 import resolve from "resolve";
 
 import bakedInHelpers from "./baked-in-helpers.js";
@@ -12,8 +11,13 @@ import { createRequire } from "node:module";
 import { pathToFileURL } from "url";
 const require = createRequire(import.meta.url);
 
-const dlvBrackets = (obj, propertyPath, defaultValue) =>
-  dlv(obj, propertyPath.replace("[", ".").replace("]", ""), defaultValue);
+function dlvBrackets(obj, key, def) {
+	const k = key.replace("[", ".").replace("]", "").split(".");
+	for (let p = 0; p < k.length; p++) {
+		obj = obj?.[k[p]];
+	}
+	return obj === undefined ? def : obj;
+}
 
 async function nodePlop(plopfilePath = "", plopCfg = {}) {
   let pkgJson = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,13 +2526,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dlv@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "dlv@npm:1.1.3"
-  checksum: 10/836459ec6b50e43e9ed388a5fc28954be99e3481af3fa4b5d82a600762eb65ef8faacd454097ed7fc2f8a60aea2800d65a4cece5cd0d81ab82b2031f3f759e6e
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:^8.1.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
@@ -4914,7 +4907,6 @@ __metadata:
     "@types/node": "npm:^24.1.0"
     "@types/picomatch": "npm:^4.0.2"
     change-case: "npm:^5.4.4"
-    dlv: "npm:^1.1.3"
     dtslint: "npm:^4.2.1"
     handlebars: "npm:^4.7.8"
     inquirer: "npm:^9.3.8"


### PR DESCRIPTION
This removes the `dlv` dependency by using a simple `.reduce` instead
